### PR TITLE
`BayesianClassifier().train()` fails without a callback.

### DIFF
--- a/lib/bayesian/bayesian.js
+++ b/lib/bayesian/bayesian.js
@@ -62,7 +62,8 @@ BayesianClassifier.prototype = {
   
   train : function(doc, cat, callback) {
     this.incDocCounts([{doc: doc, cat: cat}], function(err, ret) {
-      callback(ret);
+      if (typeof callback != 'undefined')
+        callback(ret);
     });
   },
   


### PR DESCRIPTION
I tried to call `train()` without a callback and got this stacktrace:

```
node.js:134
        throw e; // process.nextTick error, or 'error' event on first tick
        ^
TypeError: undefined is not a function
    at CALL_NON_FUNCTION (native)
    at /home/james/scottbot/node_modules/brain/lib/bayesian/bayesian.js:65:7
    at /home/james/scottbot/node_modules/brain/lib/bayesian/backends/redis.js:54:7
    at Object.callback (/home/james/scottbot/node_modules/brain/node_modules/redis/index.js:737:13)
    at RedisClient.return_reply (/home/james/scottbot/node_modules/brain/node_modules/redis/index.js:384:29)
    at RedisReplyParser.<anonymous> (/home/james/scottbot/node_modules/brain/node_modules/redis/index.js:78:14)
    at RedisReplyParser.emit (events.js:64:17)
    at RedisReplyParser.add_multi_bulk_reply (/home/james/scottbot/node_modules/brain/node_modules/redis/lib/parser/javascript.js:297:14)
    at RedisReplyParser.send_reply (/home/james/scottbot/node_modules/brain/node_modules/redis/lib/parser/javascript.js:260:18)
    at RedisReplyParser.execute (/home/james/scottbot/node_modules/brain/node_modules/redis/lib/parser/javascript.js:100:22)
```

This patch should make the callback optional so you don't have to pass in a noop function.
