### PR TITLE
package.json: jake, nomnom version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
         "redis" : ">=0.6.0"
     },
     "devDependencies" : {
-        "nomnom" : ">=0.4.3",
+        "nomnom" : ">=0.4.2",
         "cradle" : ">=0.2.5",
         "connect" : ">=1.4.0",
         "uglify-js" : ">=1.0.1",
-        "colors" : ">=0.5.0"
+        "colors" : ">=0.5.0",
+        "jake": ">=0.1.12"
     },
 
     "main": "./lib/brain"


### PR DESCRIPTION
Hello,

I was giving a try to this module and stubled across some issues in `package.json`.

`jake` was missing from the dependencies and there's no 0.4.3 `nomnom` version publicy available on the npm registry.

Btw, thanks for this module!

Regards,
Giacomo
