### PR TITLE
Support redis authentication, and be less prolific with connections

### DIFF
--- a/lib/bayesian/backends/redis.js
+++ b/lib/bayesian/backends/redis.js
@@ -11,18 +11,11 @@ var RedisBackend = function(options) {
   this.client = function() {
     if(RedisBackend.client)
       return RedisBackend.client;
-    console.log("creating client");
     var client = RedisBackend.client = redis.createClient(port, host, opts);
     if(options.error)
       client.on('error', options.error);
-    if(auth) {
-      client.auth(auth,function(err,res) {
-        if(err) {
-          console.error("Redis backend failed auth\n" + err);
-          throw err;
-        }
-      });
-    }
+    if(auth)
+      client.auth(auth);
     return client;
   };
 


### PR DESCRIPTION
Hi, thought I'd get your opinion on these two as there might be a good reason for the current implementation.

First: support redis auth.

Second: reuse a single redis client for as long as the process lasts. My redistogo instance's limit on connections made using a client per BayesianClassifier untenable. Keeping one client alive for all queries allowed me to do a lot of classification for different users (going to different keys) without connection overhead and hitting the max connection limit.

Let me know, and thanks for the great library :)
