### PR TITLE
Created `.gitignore` file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Mac.
+.DS_STORE
+
+# Node.
+node_modules
+npm-debug.log


### PR DESCRIPTION
Closes #25
- Ignores the node_modules directory because it's not needed in the repository.
- Ignores the DS_STORE file on Mac because it's pointless committing that every time.
- Ignores npm log file because it's unnecessary to store that in the repository.
