### PR TITLE
Make brain bower installable

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "brain",
+  "version": "0.0.0",
+  "homepage": "https://github.com/harthur/brain",
+  "authors": [
+    "Heather Aurthur <fayearthur@gmail.com>"
+  ],
+  "description": "Neural networks in JavaScript",
+  "main": "lib/brain.js",
+  "moduleType": [
+    "amd",
+    "es6",
+    "globals",
+    "node",
+    "yui"
+  ],
+  "license": "Public Domain",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
If you don't know, [Bower](http://www.bower.io) is a package manager for javascript. I've already created a bower.json file for you, so all you need to do is publish it by running the following.

``` Shell
sudo npm install -g bower
bower register brain git://github.com/harthur/brain.git
```

If you have any questions, please let me know.
