### PR TITLE
Fixes #37

### DIFF
--- a/lib/neuralnetwork.js
+++ b/lib/neuralnetwork.js
@@ -514,7 +514,9 @@ TrainStream.prototype.finishStreamIteration = function() {
   if (!this.dataFormatDetermined) {
     // create the lookup
     this.neuralNetwork.inputLookup = lookup.lookupFromArray(this.inputKeys);
-    this.neuralNetwork.outputLookup = lookup.lookupFromArray(this.outputKeys);
+    if(!_.isArray(this.firstDatum.output)){
+      this.neuralNetwork.outputLookup = lookup.lookupFromArray(this.outputKeys);
+    }
 
     var data = this.neuralNetwork.formatData(this.firstDatum);
     var inputSize = data[0].input.length;

--- a/stream-example.js
+++ b/stream-example.js
@@ -24,7 +24,7 @@ var trainStream = net.createTrainStream({
     console.log("trained in " + obj.iterations + " iterations with error: "
                 + obj.error);
 
-    var result = net.run([0, 1])[0];
+    var result = net.run([0, 1]);
 
     console.log("0 XOR 1: ", result);  // 0.987
   }


### PR DESCRIPTION
Fixes #37 - no need to set outputLookup if the trained `output` was an array.
