### PR TITLE
Added support for passing a function as the log option instead of using console.log.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ net.train(data, {
 
 The network will train until the training error has gone below the threshold (default `0.005`) or the max number of iterations (default `20000`) has been reached, whichever comes first.
 
-By default training won't let you know how its doing until the end, but set `log` to `true` to get periodic updates on the current training error of the network. The training error should decrease every time.
+By default training won't let you know how its doing until the end, but set `log` to `true` to get periodic updates on the current training error of the network. The training error should decrease every time. The updates will be printed to console. If you set `log` to a function, this function will be called with the updates instead of printing to the console.
 
 The learning rate is a parameter that influences how quickly the network trains. It's a number from `0` to `1`. If the learning rate is close to `0` it will take longer to train. If the learning rate is closer to `1` it will train faster but it's in danger of training to a local minimum and performing badly on new data. The default learning rate is `0.3`.
 

--- a/lib/neuralnetwork.js
+++ b/lib/neuralnetwork.js
@@ -83,7 +83,7 @@ NeuralNetwork.prototype = {
     options = options || {};
     var iterations = options.iterations || 20000;
     var errorThresh = options.errorThresh || 0.005;
-    var log = options.log || false;
+    var log = options.log ? (_.isFunction(options.log) ? options.log : console.log) : false;
     var logPeriod = options.logPeriod || 10;
     var learningRate = options.learningRate || this.learningRate || 0.3;
     var callback = options.callback;
@@ -109,7 +109,7 @@ NeuralNetwork.prototype = {
       error = sum / data.length;
 
       if (log && (i % logPeriod == 0)) {
-        console.log("iterations:", i, "training error:", error);
+        log("iterations:", i, "training error:", error);
       }
       if (callback && (i % callbackPeriod == 0)) {
         callback({ error: error, iterations: i });
@@ -455,7 +455,7 @@ function TrainStream(opts) {
   this.i = 0; // keep track of the for loop i variable that we got rid of
   this.iterations = opts.iterations || 20000;
   this.errorThresh = opts.errorThresh || 0.005;
-  this.log = opts.log || false;
+  this.log = opts.log ? (_.isFunction(opts.log) ? opts.log : console.log) : false;
   this.logPeriod = opts.logPeriod || 10;
   this.callback = opts.callback;
   this.callbackPeriod = opts.callbackPeriod || 10;
@@ -539,7 +539,7 @@ TrainStream.prototype.finishStreamIteration = function() {
   var error = this.sum / this.size;
 
   if (this.log && (this.i % this.logPeriod == 0)) {
-    console.log("iterations:", this.i, "training error:", error);
+    this.log("iterations:", this.i, "training error:", error);
   }
   if (this.callback && (this.i % this.callbackPeriod == 0)) {
     this.callback({

--- a/test/unit/options.js
+++ b/test/unit/options.js
@@ -77,4 +77,41 @@ describe('neural network options', function() {
 
     assert.ok(iters1 > (iters2 * 1.1), iters1 + " !> " + (iters2 * 1.1));
   })
+
+  describe('log', function () {
+    var logCalled;
+
+    beforeEach(function () {
+      logCalled = false;
+    });
+
+    function logFunction() {
+      logCalled = true;
+    }
+
+    function trainWithLog(log) {
+      var net = new brain.NeuralNetwork();
+      net.train([{input: [0], output: [0]}],
+        {
+          log: log,
+          logPeriod: 1
+        });
+      }
+
+      it('should call console.log if log === true', function () {
+        var originalLog = console.log;
+        console.log = logFunction;
+
+        trainWithLog(true);
+
+        console.log = originalLog;
+        assert.equal(logCalled, true);
+      })
+
+      it('should call the given log function', function () {
+        trainWithLog(logFunction);
+
+        assert.equal(logCalled, true);
+      })
+  })
 })


### PR DESCRIPTION
It's nice that the user can get a report of the training progress by passing {log: true}.
The problem is that there are some use cases where the user wants to report the progress in some other way, e.g.: if he uses the training inside the browser, and he wants to display a fancy progress bar. Passing a custom log function would solve the issue.
Note: for backwards compatibility, passing {log: true} will use console.log as the logging function.