### PR TITLE
Fixed failing test for OCR cross-validation

### DIFF
--- a/test/cross-validation/ocr.js
+++ b/test/cross-validation/ocr.js
@@ -1,7 +1,8 @@
 var canvas = require("canvas"),
     _ = require("underscore"),
     brain = require("../../lib/brain"),
-    crossValidate = require("../../lib/cross-validate");
+    crossValidate = require("../../lib/cross-validate"),
+    assert = require('assert');
 
 var dim = 24;
 
@@ -60,7 +61,7 @@ describe('OCR cross-validation', function() {
     });
 
     console.log("Cross validating");
-    var result = crossValidate(brain.NeuralNetwork, data, {});
+    var result = crossValidate(brain.NeuralNetwork, data, {}, {});
 
     console.log("\nMisclassifications:");
     result.misclasses.forEach(function(misclass) {


### PR DESCRIPTION
- assert previously undeclared at <a href=https://github.com/irfansharif/brain/blob/3c5b8262f8a00312fd58f4f227f84160166a3226/test/cross-validation/ocr.js#L85>L85</a> for `brain/test/cross-validation/ocr.js`.
- `TypeError: Cannot read property 'learningRate' of undefined` error thrown due to lack of `trainOpts` being passed into `crossValidate` function despite `trainOpts.learningRate` called on <a href=https://github.com/irfansharif/brain/blob/master/lib/cross-validate.js#L21>L21</a> for `brain/lib/cross-validate.js`